### PR TITLE
Use wine-ge-proton8.26 for better performance, and to potentially mitigate mem leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,5 +97,13 @@ COPY ./data/reg/system.reg /.wine/
 # Copy nvidia init script
 COPY ./scripts/install_nvidia_deps.sh /opt/scripts/
 
+# wine-ge
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    xz-utils
+RUN mkdir /wine-ge && \
+    curl -sL "https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton8-26/wine-lutris-GE-Proton8-26-x86_64.tar.xz" | tar xvJ -C /wine-ge
+ENV WINE=/wine-ge/lutris-GE-Proton8-26-x86_64/bin/wine
+
 COPY entrypoint.sh /usr/bin/entrypoint
 ENTRYPOINT ["/usr/bin/entrypoint"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,11 +57,12 @@ run_xvfb() {
 }
 
 run_client() {
+    echo "Using wine executable $WINE"
     if ! pgrep Xvfb; then
         echo "Xvfb process not found. Restarting Xvfb."
         run_xvfb
     fi
-    WINEDEBUG=-all $XVFB_RUN wine $EFT_BINARY $BATCHMODE $NOGRAPHICS $NODYNAMICAI -token="$PROFILE_ID" -config="{'BackendUrl':'http://$SERVER_URL:$SERVER_PORT', 'Version':'live'}"
+    WINEDEBUG=-all $XVFB_RUN $WINE $EFT_BINARY $BATCHMODE $NOGRAPHICS $NODYNAMICAI -token="$PROFILE_ID" -config="{'BackendUrl':'http://$SERVER_URL:$SERVER_PORT', 'Version':'live'}"
 }
 
 if [ "$USE_MODSYNC" == "true" ]; then


### PR DESCRIPTION
Seems to perform a bit better. About 5 to 10 extra FPS on the dedicated client. Also seems to solve the slow memory leak that occurs on some maps like Lighthouse.

Test system specs are i5 4690k overclocked to 4.2Ghz, 24Gb of DDR3 1333Mhz RAM
Bot despawns, AI limiting at 300m via SWAG+DONUTS.

Lighthouse running about 26 bots shows roughly 11-12Gb RAM throughout the entire raid. I'm getting consistently >30FPS sitting in a bush at the Convenience store.
On `wine-devel`, the same position with roughly the same number of bots would get me about 18-22FPS, and client RAM usage would slowly climb until it exhausts all available RAM and the container is OOM killed.

