### PR TITLE
Add ability to auto restart client on raid end

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ If the dedicated client container crashes with this error, this usually means yo
   ```
 
 ### Container stalls at wine: RLIMIT_NICE is <=20
-This happens sometimes when the container is force-recreated e.g. by `docker-compose up --force-recreate`. I have no idea why it happens, but to solve it you can
+This happens sometimes on first boot or when the container is force-recreated e.g. by `docker-compose up --force-recreate`. I have no idea why it happens, but to solve it you can
 - Just wait. Almost exactly 5 minutes after this line is emitted, the client will resume starting normally
-- Recreate the container again by stopping and deleting it, then bringing it back up with `docker run` or `docker-compose up`
+- Restart the container with `docker restart` or `docker-compose restart`. This will force the client to start up immediately.
 
 # Development
 ### Building

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ This happens sometimes on first boot or when the container is force-recreated e.
 - Just wait. Almost exactly 5 minutes after this line is emitted, the client will resume starting normally
 - Restart the container with `docker restart` or `docker-compose restart`. This will force the client to start up immediately.
 
+### My container memory usage keeps going up until I run out of memory
+- Try setting the `AUTO_RESTART_ON_RAID_END` env var to `true`, to have the client restart itself after each raid is completed and all players have extracted.
+  This should effectively reset container memory usage back to the ~3Gb required on first boot, after each raid.
+- EFT is extremely memory hungry, if you are running out of memory while in raid, try to remove some mods that may be memory intensive to see if memory usage improves.
+- There may be no better solution than to simply add more RAM to the docker host.
+
 # Development
 ### Building
 Run the `build` script, optionally setting a `VERSION` env var to tag the image. The image is tagged `fika-dedicated:latest`, or whatever version is provided in the env var.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@
     + [Building](#building)
     + [Using an Nvidia GPU in the container](#using-an-nvidia-gpu-in-the-container)
 
+# Features
+- Run Fika Dedicated client fully headless in docker container, with or without GPU on the docker host.
+- Supports [Corter-ModSync](https://github.com/c-orter/modsync/), to automatically keep dedicated client mods up to date
+- Automatic restart on raid end, to manage container memory usage
+- Automatic purging of EFT `Logs/` dir, to clear out large logfiles due to logspam
+- Optionally use Nvidia GPU when running the client, still completely headless without a real display
+
 # Releases
 The image build is triggered off git tags and hosted on ghcr. `latest` will always point to the latest version.
 ```

--- a/README.md
+++ b/README.md
@@ -134,12 +134,13 @@ The start script will then:
 
 ## Optional
 
-| Env var                | Description                                                                                                                                            |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `USE_DGPU`             | If set to `true`, enable passing a GPU resource into the container with `nvidia-container-toolkit`. Make sure you have the required dependencies installed for your host |
-| `DISABLE_NODYNAMICAI`  | If set to `true`, removes the `-noDynamicAI` parameter when starting the client, allowing the use of Fika's dynamic AI feature. Can help with dedicated client performance if you notice server FPS dropping below 30 |
-| `USE_MODSYNC`          | If set to `true`, enables support for Corter-ModSync 0.8.1+ and the external updater. On container start, the dedicated client will close and start the updater the modsync plugin detects changes. On completion, the script will start the dedicated client up again |
-| `ENABLE_LOG_PURGE`     | If set to `true`, automatically purge the EFT `Logs/` directory every 00:00 UTC, to clear out large logfiles due to logspam. |
+| Env var                        | Description                                                                                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `USE_DGPU`                     | If set to `true`, enable passing a GPU resource into the container with `nvidia-container-toolkit`. Make sure you have the required dependencies installed for your host |
+| `DISABLE_NODYNAMICAI`          | If set to `true`, removes the `-noDynamicAI` parameter when starting the client, allowing the use of Fika's dynamic AI feature. Can help with dedicated client performance if you notice server FPS dropping below 30 |
+| `USE_MODSYNC`                  | If set to `true`, enables support for Corter-ModSync 0.8.1+ and the external updater. On container start, the dedicated client will close and start the updater the modsync plugin detects changes. On completion, the script will start the dedicated client up again |
+| `ENABLE_LOG_PURGE`             | If set to `true`, automatically purge the EFT `Logs/` directory every 00:00 UTC, to clear out large logfiles due to logspam. |
+| `AUTO_RESTART_ON_RAID_END`     | If set to `true`, detects the line `Destroyed FikaServer` in the BepInEx logs to auto restart the client on raid end, clearing memory |
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ If the dedicated client container crashes with this error, this usually means yo
   vm.max_map_count = 2147483642
   ```
 
+### Container stalls at wine: RLIMIT_NICE is <=20
+This happens sometimes when the container is force-recreated e.g. by `docker-compose up --force-recreate`. I have no idea why it happens, but to solve it you can
+- Just wait. Almost exactly 5 minutes after this line is emitted, the client will resume starting normally
+- Recreate the container again by stopping and deleting it, then bringing it back up with `docker run` or `docker-compose up`
+
 # Development
 ### Building
 Run the `build` script, optionally setting a `VERSION` env var to tag the image. The image is tagged `fika-dedicated:latest`, or whatever version is provided in the env var.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,7 +76,10 @@ run_client() {
     # Blocking function
     if [[ "$AUTO_RESTART_ON_RAID_END" == "true" ]]; then
         echo "Starting logfile watch for auto-restart on raid end"
-        grep -q "Destroyed FikaServer" <(tail -F -n 0 $logfile) && exit 0
+        grep -q "Destroyed FikaServer" <(tail -F -n 0 $logfile) \
+            && echo "Raid ended, restarting dedicated client" \
+            && sleep 10 \
+            && exit 0
     else
         echo "Waiting for EFT to exit"
         tail --pid=$eft_pid -f /dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,6 +121,6 @@ if [[ "$USE_MODSYNC" == "true" || "$AUTO_RESTART_ON_RAID_END" == "true" ]]; then
         sleep 5
     done
 else
-    run_xvfb
+    #run_xvfb
     run_client
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,15 +110,14 @@ if [[ "$ENABLE_LOG_PURGE" == "true" ]]; then
     start_crond
 fi
 
+run_xvfb
 if [[ "$USE_MODSYNC" == "true" || "$AUTO_RESTART_ON_RAID_END" == "true" ]]; then
     while true; do
         # Anticipate the client exiting due to modsync or raid end, and restart it
-        run_xvfb
         run_client
         echo "Dedi client closed with exit code $?. Restarting.." >&2
         sleep 5
     done
 else
-    run_xvfb
     run_client
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,6 +91,7 @@ run_client() {
     echo "EFT PID is $eft_pid"
 
     # Blocking function
+    # TODO to make this more extensible, can these be turned into functions and have this function wait for them to complete?
     if [[ "$AUTO_RESTART_ON_RAID_END" == "true" ]]; then
         echo "Starting logfile watch for auto-restart on raid end"
         grep -q "Destroyed FikaServer" <(tail -F -n 0 $logfile) \


### PR DESCRIPTION
Helps clear out memory usage from the client, since memory does not appear to be freed properly after raid end.

We watch for the logline `Destroyed FikaServer` in the `BepInEx/LogOutput.log` file emitted immediately after the fika plugin calls `CoopGame.Dispose` (in this [line here](https://github.com/project-fika/Fika-Plugin/blob/124733c47c59371da4d9c596d649074841e40a5e/Fika.Core/Coop/Utils/NetManagerUtils.cs#L100))

Also cleaned up the entrypoint and made xvfb run in background by default.