### PR TITLE
Add wineboot --update on startup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN apt-get update \
     xz-utils
 RUN mkdir /wine-ge && \
     curl -sL "https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton8-26/wine-lutris-GE-Proton8-26-x86_64.tar.xz" | tar xvJ -C /wine-ge
-ENV WINE=/wine-ge/lutris-GE-Proton8-26-x86_64/bin/wine
+ENV WINE_BIN_PATH=/wine-ge/lutris-GE-Proton8-26-x86_64/bin
 
 COPY ./scripts/purge_logs.sh /usr/bin/purge_logs
 COPY ./data/cron/cron_purge_logs /opt/cron/cron_purge_logs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,7 +108,7 @@ run_client() {
     fi
 }
 
-echo "Update using wineboot. See $wine_logfile_name for logs."
+echo "Running wineboot update. Please wait ~60s. See $wine_logfile_name for logs."
 $WINE_BIN_PATH/wineboot --update &> $wine_logfile
 
 if [[ "$ENABLE_LOG_PURGE" == "true" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,10 @@
 eft_dir=/opt/tarkov
 eft_binary=$eft_dir/EscapeFromTarkov.exe
 logfile=$eft_dir/BepInEx/LogOutput.log
+
+wine_logfile_name=wine.log
+wine_logfile=$eft_dir/$wine_logfile_name
+
 xvfb_run=""
 nographics="-nographics"
 batchmode="-batchmode"
@@ -84,8 +88,8 @@ start_crond() {
 # via watching for raid end (if autorestart is enabled)
 # or via watching the PID
 run_client() {
-    echo "Using wine executable $WINE"
-    WINEDEBUG=-all $xvfb_run $WINE $eft_binary $batchmode $nographics $nodynamicai -token="$PROFILE_ID" -config="{'BackendUrl':'http://$SERVER_URL:$SERVER_PORT', 'Version':'live'}" &
+    echo "Using wine executable $WINE_BIN_PATH/wine"
+    WINEDEBUG=-all $xvfb_run $WINE_BIN_PATH/wine $eft_binary $batchmode $nographics $nodynamicai -token="$PROFILE_ID" -config="{'BackendUrl':'http://$SERVER_URL:$SERVER_PORT', 'Version':'live'}" &
 
     eft_pid=$!
     echo "EFT PID is $eft_pid"
@@ -103,6 +107,9 @@ run_client() {
         tail --pid=$eft_pid -f /dev/null
     fi
 }
+
+echo "Update using wineboot. See $wine_logfile_name for logs."
+$WINE_BIN_PATH/wineboot --update &> $wine_logfile
 
 if [[ "$ENABLE_LOG_PURGE" == "true" ]]; then
     echo "Enabling log purge"


### PR DESCRIPTION
I did a pinch of debugging (changed `WINEDEBUG=-all` to `WINEDEBUG=warn+all` and looked through the mounting of logs that came out as a result). I found that the 5 minute delay at boot when is caused by it hanging on wineboot. It does a bunch of setting up, then just sits, and then after almost exactly 5 minutes (+/- 10 seconds) the error `run_wineboot boot event wait timed out` comes up, which is descriptive enough to indicate it was the cause of the 5 minute delay, so I went looking for how to resolve that.

My bit of research said that just running `wineboot --update` fixes that error, and that held up in my testing.

It takes maybe 10-20 seconds to run but in my testing it brings the overall time from cold boot (no container) to `WebSocketHandler "FikaDedicatedRaidService" connected` appearing in the backend logs to 30-60 seconds.

I sent the output to a log file because it outputs a bunch that most people won't care about or want in their main logs.

Sources
* WINEDEBUG Options: https://gitlab.winehq.org/wine/wine/-/wikis/Commands/wineboot
* winboot discussions:
  * https://bbs.archlinux.org/viewtopic.php?id=268151
  * https://bbs.archlinux.org/viewtopic.php?id=268459