### PR TITLE
Follow BepInEx logs instead of Wine logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN apt-get update \
     xz-utils
 RUN mkdir /wine-ge && \
     curl -sL "https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton8-26/wine-lutris-GE-Proton8-26-x86_64.tar.xz" | tar xvJ -C /wine-ge
-ENV WINE=/wine-ge/lutris-GE-Proton8-26-x86_64/bin/wine
+ENV WINE_BIN_PATH=/wine-ge/lutris-GE-Proton8-26-x86_64/bin
 
 COPY ./scripts/purge_logs.sh /usr/bin/purge_logs
 COPY ./data/cron/cron_purge_logs /opt/cron/cron_purge_logs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,9 +110,6 @@ run_client() {
     fi
 }
 
-echo "Update using wineboot. See $wine_logfile_name for logs."
-$WINE_BIN_PATH/wineboot --update &> $wine_logfile
-
 if [[ "$ENABLE_LOG_PURGE" == "true" ]]; then
     echo "Enabling log purge"
     cp /opt/cron/cron_purge_logs /etc/cron.d/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,10 @@
 eft_dir=/opt/tarkov
 eft_binary=$eft_dir/EscapeFromTarkov.exe
 logfile=$eft_dir/BepInEx/LogOutput.log
+
+wine_logfile_name=wine.log
+wine_logfile=$eft_dir/$wine_logfile_name
+
 xvfb_run=""
 nographics="-nographics"
 batchmode="-batchmode"
@@ -84,8 +88,8 @@ start_crond() {
 # via watching for raid end (if autorestart is enabled)
 # or via watching the PID
 run_client() {
-    echo "Using wine executable $WINE"
-    WINEDEBUG=-all $xvfb_run $WINE $eft_binary $batchmode $nographics $nodynamicai -token="$PROFILE_ID" -config="{'BackendUrl':'http://$SERVER_URL:$SERVER_PORT', 'Version':'live'}" &
+    echo "Using wine executable $WINE_BIN_PATH/wine"
+    WINEDEBUG=-all $xvfb_run $WINE_BIN_PATH/wine $eft_binary $batchmode $nographics $nodynamicai -token="$PROFILE_ID" -config="{'BackendUrl':'http://$SERVER_URL:$SERVER_PORT', 'Version':'live'}" &
 
     eft_pid=$!
     echo "EFT PID is $eft_pid"
@@ -103,6 +107,9 @@ run_client() {
         tail --pid=$eft_pid -f /dev/null
     fi
 }
+
+echo "Update using wineboot. See $wine_logfile_name for logs."
+$WINE_BIN_PATH/wineboot --update &> $wine_logfile
 
 if [[ "$ENABLE_LOG_PURGE" == "true" ]]; then
     echo "Enabling log purge"


### PR DESCRIPTION
I was thinking that the wine logs aren't really all that helpful in most regular use cases but the BepInEx logs could be, so I wondered what you thought of sending all the wine logs elsewhere and watching the BepInEx logs instead (I use portainer to manage most of my containers so this is what would appear if I just look at the container logs).

Includes/depends on the changes from #14 as developed them together and I just send the wine logs to the same log file. I figured that #14 was pretty cut and dry so it would likely already be merged if/when this PR is, whereas this PR we may want to discuss more (like if you have a better idea than using `tail`). ~~I can separate it more thoroughly if you'd prefer.~~ I removed main `winboot --update` line that would conflict with the changes in that PR.